### PR TITLE
Next step now requires 10 to 1000 characters if not empty.

### DIFF
--- a/src/KWFCI/Models/Interaction.cs
+++ b/src/KWFCI/Models/Interaction.cs
@@ -9,6 +9,7 @@ namespace KWFCI.Models
         [StringLength(1000, MinimumLength = 10, ErrorMessage = "Notes requires between 10 and 1000 characters.")]
         public string Notes { get; set; }
         public DateTime? DateCreated { get; set; }
+        [StringLength(1000, MinimumLength = 10, ErrorMessage = "Next Step requires between 10 and 1000 characters.")]
         public string NextStep { get; set; }
         public int? TaskForeignKey { get; set; }
         public string Status { get; set; }

--- a/src/KWFCI/Views/Shared/Modals/_EditInteractionNextStepModal.cshtml
+++ b/src/KWFCI/Views/Shared/Modals/_EditInteractionNextStepModal.cshtml
@@ -10,6 +10,7 @@
             <div class="modal-body clearfix">
 
                 <form asp-controller="Interactions" asp-action="Edit" method="post">
+                    <div asp-validation-summary="All" class="text-danger center-block"></div>
                     <div class="form-group center-block modal-form">
 
                         <textarea asp-for="@Model.NewInteraction.NextStep" class="form-control" rows="7" cols="10"></textarea>


### PR DESCRIPTION
Validation was working for me for both admin and staff with this change.

fixes #187 